### PR TITLE
Declare fs and user features for nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ in-container = "1.1.0"
 lava_torrent = "0.11.1"
 log = "0.4.20"
 magnet-url = "2.0.0"
-nix = "0.27.1"
+nix = { version = "0.27.1", features = ["fs", "user"] }
 reqwest = { version = "0.11", default-features = false, features = [
     "json",
     "multipart",


### PR DESCRIPTION
Without this change `cargo install putioarr` failed with the following errors:

```
error[E0432]: unresolved import `nix::unistd::Uid`
  --> src/download_system/download.rs:10:5
   |
10 | use nix::unistd::Uid;
   |     ^^^^^^^^^^^^^^^^ no `Uid` in `unistd`
   |
note: found an item that was configured out
  --> /Users/matthias/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.27.1/src/unistd.rs:74:12
   |
74 | pub struct Uid(uid_t);
   |            ^^^
   = note: the item is gated behind the `user` feature

error[E0425]: cannot find function `isatty` in module `nix::unistd`
    --> src/main.rs:103:52
     |
103  |             } else if let Ok(istty) = nix::unistd::isatty(0) {
     |                                                    ^^^^^^ not found in `nix::unistd`
     |
note: found an item that was configured out
    --> /Users/matthias/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.27.1/src/unistd.rs:1264:8
     |
1264 | pub fn isatty(fd: RawFd) -> Result<bool> {
     |        ^^^^^^
     = note: the item is gated behind the `fs` feature
```