### PR TITLE
Support lidarr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "putioarr"
-description = "put.io to sonarr/radarr/whisparr proxy"
+description = "put.io to sonarr/radarr/whisparr/lidarr proxy"
 authors = ["Wouter de Bie <wouter@evenflow.nl"]
 repository = "https://github.com/wouterdebie/putioarr"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # putioarr
 
-Proxy that allows put.io to be used as a download client for sonarr/radarr/whisparr. The proxy uses the Transmission protocol.
+Proxy that allows put.io to be used as a download client for sonarr/radarr/whisparr/lidarr. The proxy uses the Transmission protocol.
 
 ## Installation
 
@@ -14,10 +14,10 @@ Make sure you have a [proper rust installation](https://www.rust-lang.org/tools/
 
 First, generate a config using `putio generate-config`. This will generate a config file in `~/.config/putioarr/config.toml`. Use `-c` to override the configuration file location.
 
-Edit the configuration file and make sure you configure the username and password, as well as the sonarr/radarr/whisparr details.
+Edit the configuration file and make sure you configure the username and password, as well as the sonarr/radarr/whisparr/lidarr details.
 
 - Run the proxy:`putioarr run`
-- Configure the Transmission download client in sonarr/radarr/whisparr:
+- Configure the Transmission download client in sonarr/radarr/whisparr/lidarr:
     - Url Base: /transmission
     - Username: <configured username>
     - Password: <configured password>
@@ -29,7 +29,7 @@ Docker images are based on [linuxserver.io](https://linuxserver.io) images.
 
 #### Usage
 
-The first time you run your docker container, run it without the `-d` option, since you'll need a put.io API key. When no configuration is found, it will present you a link and a code that will generate an API key. After the key is generated, putioarr will write a default config in your config volume (see `docker compose` and `docker cli` below). Modify the config (like username, password and sonarr/radarr/whisparr configuration) in order to properly use putioarr.
+The first time you run your docker container, run it without the `-d` option, since you'll need a put.io API key. When no configuration is found, it will present you a link and a code that will generate an API key. After the key is generated, putioarr will write a default config in your config volume (see `docker compose` and `docker cli` below). Modify the config (like username, password and sonarr/radarr/whisparr/lidarr configuration) in order to properly use putioarr.
 
 #### Supported Architectures
 
@@ -88,7 +88,7 @@ Container images are configured using parameters passed at runtime (such as thos
 
 
 ## Behavior
-The proxy will upload torrents or magnet links to put.io. It will then continue to monitor transfers. When a transfer is completed, all files belonging to the transfer will be downloaded to the specified download directory. The proxy will remove the files after sonarr/radarr/whisparr has imported them and put.io is done seeding. The proxy will skip directories named "Sample".
+The proxy will upload torrents or magnet links to put.io. It will then continue to monitor transfers. When a transfer is completed, all files belonging to the transfer will be downloaded to the specified download directory. The proxy will remove the files after sonarr/radarr/whisparr/lidarr has imported them and put.io is done seeding. The proxy will skip directories named "Sample".
 
 ## Configuration
 A configuration file can be specified using `-c`, but the default configuration file location is:
@@ -97,12 +97,12 @@ A configuration file can be specified using `-c`, but the default configuration 
 
 TOML is used as the configuration format:
 ```
-# Required. Username and password that sonarr/radarr/whisparr use to connect to the proxy
+# Required. Username and password that sonarr/radarr/whisparr/lidarr use to connect to the proxy
 username = "myusername"
 password = "mypassword"
 
 # Required. Directory where the proxy will download files to. This directory has to be readable by
-# sonarr/radarr/whisparr in order to import downloads
+# sonarr/radarr/whisparr/lidarr in order to import downloads
 download_directory = "/path/to/downloads"
 
 # Optional bind address, default "0.0.0.0"
@@ -150,7 +150,7 @@ api_key = "MYRADARRAPIKEY"
 - Better Error handling and retry behavior
 - The session ID provided is hard coded. Not sure if it matters.
 - (Add option to not delete downloads)
-- Figure out a better way to map a transfer to a completed import. Since a transfer can contain multiple files (e.g. a whole season) we currently check if all video files have been imported. Most of the time this is fine, except when there are sample videos. sonarr/radarr/whisparr will not import samples, but will make no mention of the fact that the sample was skipped. Right now we check against the `skip_directories` list, which works, but might be tedious.
+- Figure out a better way to map a transfer to a completed import. Since a transfer can contain multiple files (e.g. a whole season) we currently check if all video files have been imported. Most of the time this is fine, except when there are sample videos. sonarr/radarr/whisparr/lidarr will not import samples, but will make no mention of the fact that the sample was skipped. Right now we check against the `skip_directories` list, which works, but might be tedious.
 - Automatically pick the right putio proxy based on speed
 
 ## Thanks

--- a/root/defaults/config.toml
+++ b/root/defaults/config.toml
@@ -50,3 +50,8 @@ api_key = ""
 # url = "http://mywhisparrhost:6969/radarr"
 # Can be found in Radarr: Settings -> General
 # api_key = "MYWHISPARRAPIKEY"
+
+# [lidarr]
+# url = "http://mylidarrhost:6969/lidarr"
+# Can be found in Lidarr: Settings -> General
+# api_key = "MYLIDARRAPIKEY"

--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -41,7 +41,7 @@ impl Transfer {
         for target in targets {
             let mut service_results = vec![];
             for app in &apps {
-                let service_result = match app.check_imported(&target.to).await {
+                let service_result = match app.check_imported(&target).await {
                     Ok(r) => r,
                     Err(e) => {
                         error!("Error retrieving history from {}: {}", app, e);
@@ -129,6 +129,7 @@ async fn recurse_download_targets(
                     to,
                     top_level,
                     transfer_hash: hash.to_string(),
+                    media_type: None,
                 });
 
                 for file in response.files {
@@ -154,6 +155,7 @@ async fn recurse_download_targets(
                 to,
                 top_level,
                 transfer_hash: hash.to_string(),
+                media_type: MediaType::from_file_type_str(response.parent.file_type.as_str()),
             });
         }
         _ => {
@@ -175,6 +177,22 @@ pub enum TransferMessage {
     Imported(Transfer),
 }
 
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub enum MediaType {
+    Audio,
+    Video,
+}
+
+impl MediaType {
+    pub fn from_file_type_str(file_type: &str) -> Option<Self> {
+        match file_type {
+            "AUDIO" => Some(Self::Audio),
+            "VIDEO" => Some(Self::Video),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DownloadTarget {
     pub from: Option<String>,
@@ -182,6 +200,7 @@ pub struct DownloadTarget {
     pub target_type: TargetType,
     pub top_level: bool,
     pub transfer_hash: String,
+    pub media_type: Option<MediaType>,
 }
 
 impl Display for DownloadTarget {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ pub struct Config {
     sonarr: Option<ArrConfig>,
     radarr: Option<ArrConfig>,
     whisparr: Option<ArrConfig>,
+    lidarr: Option<ArrConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::{http::routes, services::putio};
+use crate::{http::routes, services::arr, services::putio};
 use actix_web::{web, App, HttpServer};
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
@@ -55,20 +55,14 @@ pub struct Config {
     uid: u32,
     username: String,
     putio: PutioConfig,
-    sonarr: Option<ArrConfig>,
-    radarr: Option<ArrConfig>,
-    whisparr: Option<ArrConfig>,
-    lidarr: Option<ArrConfig>,
+    sonarr: Option<arr::ArrConfig>,
+    radarr: Option<arr::ArrConfig>,
+    whisparr: Option<arr::ArrConfig>,
+    lidarr: Option<arr::ArrConfig>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PutioConfig {
-    api_key: String,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct ArrConfig {
-    url: String,
     api_key: String,
 }
 

--- a/src/services/arr.rs
+++ b/src/services/arr.rs
@@ -1,6 +1,14 @@
+use crate::Config;
 use anyhow::{bail, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ArrConfig {
+    url: String,
+    api_key: String,
+}
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -16,48 +24,113 @@ pub struct ArrHistoryRecord {
     pub data: HashMap<String, Option<String>>,
 }
 
-pub async fn check_imported(target: &str, api_key: &str, base_url: &str, is_lidarr: &bool) -> Result<bool> {
-    let client = reqwest::Client::new();
-    let mut inspected = 0;
-    let mut page = 0;
-    loop {
-        let mut url = format!(
-            "{base_url}/api/v3/history?includeSeries=false&includeEpisode=false&page={page}&pageSize=1000");
-        if *is_lidarr {
-            url = format!(
-                "{base_url}/api/v1/history?includeArtist=false&includeAlbum=false&includeTrack=false&page={page}&pageSize=1000");
+#[derive(Debug)]
+pub enum ArrAppType {
+    Lidarr,
+    Radarr,
+    Sonarr,
+    Whisparr,
+}
+
+pub struct ArrApp {
+    app_type: ArrAppType,
+    config: ArrConfig,
+    client: reqwest::Client,
+}
+
+impl ArrApp {
+    pub fn new(app_type: ArrAppType, config: &ArrConfig) -> Self {
+        Self {
+            app_type: app_type,
+            config: config.clone(),
+            client: reqwest::Client::new(),
         }
+    }
 
-        let response = client.get(&url).header("X-Api-Key", api_key).send().await?;
-
-        let status = response.status();
-
-        if !status.is_success() {
-            bail!("url: {}, status: {}", url, status);
+    pub fn from_config(config: &Config) -> Vec<Self> {
+        let mut apps = vec![];
+        if let Some(c) = &config.lidarr {
+            apps.push(Self::new(ArrAppType::Lidarr, c));
         }
-
-        let bytes = response.bytes().await?;
-        let json: serde_json::Result<ArrHistoryResponse> = serde_json::from_slice(&bytes);
-        if json.is_err() {
-            bail!("url: {url}, status: {status}, body: {bytes:?}");
+        if let Some(c) = &config.radarr {
+            apps.push(Self::new(ArrAppType::Radarr, c));
         }
-        let history_response: ArrHistoryResponse = json?;
+        if let Some(c) = &config.sonarr {
+            apps.push(Self::new(ArrAppType::Sonarr, c));
+        }
+        if let Some(c) = &config.whisparr {
+            apps.push(Self::new(ArrAppType::Whisparr, c));
+        }
+        apps
+    }
 
-        for record in history_response.records {
-            if (record.event_type == "downloadFolderImported" || record.event_type == "trackFileImported")
-                && record.data["droppedPath"].as_ref().unwrap() == target
-            {
-                return Ok(true);
-            } else {
-                inspected += 1;
-                continue;
+    fn url(&self, page: u32) -> String {
+        match &self.app_type {
+            ArrAppType::Radarr | ArrAppType::Sonarr | ArrAppType::Whisparr => {
+                format!(
+            "{0}/api/v3/history?includeSeries=false&includeEpisode=false&page={page}&pageSize=1000", self.config.url)
+            }
+            ArrAppType::Lidarr => {
+                format!(
+                "{0}/api/v1/history?includeArtist=false&includeAlbum=false&includeTrack=false&page={page}&pageSize=1000", self.config.url)
             }
         }
+    }
 
-        if history_response.total_records < inspected {
-            page += 1;
-        } else {
-            return Ok(false);
+    async fn get(&self, page: u32) -> Result<reqwest::Response, reqwest::Error> {
+        self.client
+            .get(self.url(page))
+            .header("X-Api-Key", &self.config.api_key)
+            .send()
+            .await
+    }
+
+    pub async fn check_imported(&self, target: &str) -> Result<bool> {
+        let mut inspected = 0;
+        let mut page = 0;
+        loop {
+            let response = self.get(page).await?;
+            let status = response.status();
+
+            if !status.is_success() {
+                bail!("url: {}, status: {}", self.url(page), status);
+            }
+
+            let bytes = response.bytes().await?;
+            let json: serde_json::Result<ArrHistoryResponse> = serde_json::from_slice(&bytes);
+            if json.is_err() {
+                bail!(
+                    "url: {}, status: {}, body: {:?}",
+                    self.url(page),
+                    status,
+                    bytes
+                );
+            }
+            let history_response: ArrHistoryResponse = json?;
+
+            for record in history_response.records {
+                if (record.event_type == "downloadFolderImported"
+                    || record.event_type == "trackFileImported")
+                    && record.data["droppedPath"].as_ref().unwrap() == target
+                {
+                    return Ok(true);
+                } else {
+                    inspected += 1;
+                    continue;
+                }
+            }
+
+            if history_response.total_records < inspected {
+                page += 1;
+            } else {
+                return Ok(false);
+            }
         }
+    }
+}
+
+impl fmt::Display for ArrApp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.app_type)
     }
 }

--- a/src/services/arr.rs
+++ b/src/services/arr.rs
@@ -1,4 +1,4 @@
-use crate::{Config, download_system::transfer};
+use crate::{download_system::transfer, Config};
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -61,7 +61,11 @@ impl ArrApp {
             apps.push(Self::new(ArrAppType::Sonarr, c, transfer::MediaType::Video));
         }
         if let Some(c) = &config.whisparr {
-            apps.push(Self::new(ArrAppType::Whisparr, c, transfer::MediaType::Video));
+            apps.push(Self::new(
+                ArrAppType::Whisparr,
+                c,
+                transfer::MediaType::Video,
+            ));
         }
         apps
     }
@@ -95,7 +99,7 @@ impl ArrApp {
                 } else {
                     Ok(true)
                 }
-            },
+            }
             None => {
                 bail!("Cannot check files with no media type: {}", target);
             }
@@ -104,7 +108,7 @@ impl ArrApp {
 
     pub async fn check_imported(&self, target: &transfer::DownloadTarget) -> Result<bool> {
         if !self.should_handle(target)? {
-            return Ok(false)
+            return Ok(false);
         }
         let mut inspected = 0;
         let mut page = 0;

--- a/src/services/arr.rs
+++ b/src/services/arr.rs
@@ -1,4 +1,4 @@
-use crate::Config;
+use crate::{Config, download_system::transfer};
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -36,30 +36,32 @@ pub struct ArrApp {
     app_type: ArrAppType,
     config: ArrConfig,
     client: reqwest::Client,
+    media_type: transfer::MediaType,
 }
 
 impl ArrApp {
-    pub fn new(app_type: ArrAppType, config: &ArrConfig) -> Self {
+    pub fn new(app_type: ArrAppType, config: &ArrConfig, media_type: transfer::MediaType) -> Self {
         Self {
             app_type: app_type,
             config: config.clone(),
             client: reqwest::Client::new(),
+            media_type: media_type,
         }
     }
 
     pub fn from_config(config: &Config) -> Vec<Self> {
         let mut apps = vec![];
         if let Some(c) = &config.lidarr {
-            apps.push(Self::new(ArrAppType::Lidarr, c));
+            apps.push(Self::new(ArrAppType::Lidarr, c, transfer::MediaType::Audio));
         }
         if let Some(c) = &config.radarr {
-            apps.push(Self::new(ArrAppType::Radarr, c));
+            apps.push(Self::new(ArrAppType::Radarr, c, transfer::MediaType::Video));
         }
         if let Some(c) = &config.sonarr {
-            apps.push(Self::new(ArrAppType::Sonarr, c));
+            apps.push(Self::new(ArrAppType::Sonarr, c, transfer::MediaType::Video));
         }
         if let Some(c) = &config.whisparr {
-            apps.push(Self::new(ArrAppType::Whisparr, c));
+            apps.push(Self::new(ArrAppType::Whisparr, c, transfer::MediaType::Video));
         }
         apps
     }
@@ -85,7 +87,25 @@ impl ArrApp {
             .await
     }
 
-    pub async fn check_imported(&self, target: &str) -> Result<bool> {
+    fn should_handle(&self, target: &transfer::DownloadTarget) -> Result<bool> {
+        match &target.media_type {
+            Some(mt) => {
+                if *mt != self.media_type {
+                    Ok(false)
+                } else {
+                    Ok(true)
+                }
+            },
+            None => {
+                bail!("Cannot check files with no media type: {}", target);
+            }
+        }
+    }
+
+    pub async fn check_imported(&self, target: &transfer::DownloadTarget) -> Result<bool> {
+        if !self.should_handle(target)? {
+            return Ok(false)
+        }
         let mut inspected = 0;
         let mut page = 0;
         loop {
@@ -111,7 +131,7 @@ impl ArrApp {
             for record in history_response.records {
                 if (record.event_type == "downloadFolderImported"
                     || record.event_type == "trackFileImported")
-                    && record.data["droppedPath"].as_ref().unwrap() == target
+                    && record.data["droppedPath"].as_ref().unwrap() == &target.to
                 {
                     return Ok(true);
                 } else {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,3 @@
-pub mod transmission;
-pub mod putio;
 pub mod arr;
+pub mod putio;
+pub mod transmission;

--- a/src/services/putio.rs
+++ b/src/services/putio.rs
@@ -38,8 +38,7 @@ impl PutIOTransfer {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct AccountInfoResponse {
-}
+pub struct AccountInfoResponse {}
 
 pub async fn account_info(api_token: &str) -> Result<AccountInfoResponse> {
     let client = reqwest::Client::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,9 +55,14 @@ url = "http://myradarrhost:7878/radarr"
 api_key = "MYRADARRAPIKEY"
 
 [whisparr]
-url = "http://mywhisparrhost:6969/radarr"
+url = "http://mywhisparrhost:6969/whisparr"
 # Can be found in Settings -> General
 api_key = "MYWHISPARRAPIKEY"
+
+[lidarr]
+url = "http://mylidarrhost:6969/lidarr"
+# Can be found in Settings -> General
+api_key = "MYLIDARRAPIKEY"
 
 "#;
 


### PR DESCRIPTION
This adds support for lidarr. It has been working for me well in the past few days.

main difference is that the API endpoint for history is slightly different (URL and returned json) and add support for AUDIO file type.

is_imported might get a slight improvement if to add the service only for audios, instead of checking all services (lidarr, sonarr, radarr, whisparr) for each file. But I tried to make the least amount of changes.