### PR TITLE
Implement category-specific download directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,45 @@ api_key =  "MYPUTIOKEY"
 url = "http://mysonarrhost:8989/sonarr"
 # Can be found in Settings -> General
 api_key = "MYSONARRAPIKEY"
+# Optional: Download to a category-specific subdirectory (e.g., /downloads/tv/)
+# category = "tv"
 
 [radarr]
 url = "http://myradarrhost:7878/radarr"
 # Can be found in Settings -> General
 api_key = "MYRADARRAPIKEY"
+# Optional: Download to a category-specific subdirectory (e.g., /downloads/movies/)
+# category = "movies"
+
+[whisparr]
+url = "http://mywhisparrhost:6969/whisparr"
+# Can be found in Settings -> General
+api_key = "MYWHISPARRAPIKEY"
+# Optional: Download to a category-specific subdirectory (e.g., /downloads/adult/)
+# category = "adult"
 ```
+
+### Category-based Download Directories
+
+To prevent Sonarr/Radarr/Whisparr from seeing each other's downloads, you can configure separate download directories using categories:
+
+1. **In putioarr's config.toml**, add a `category` field to each service:
+   ```toml
+   [sonarr]
+   category = "tv"
+   
+   [radarr]
+   category = "movies"
+   ```
+
+2. **In Sonarr/Radarr/Whisparr's download client settings**, set the same category in the Transmission configuration.
+
+3. Downloads will then be organized into subdirectories:
+   - Sonarr downloads → `/download_directory/tv/`
+   - Radarr downloads → `/download_directory/movies/`
+   - Whisparr downloads → `/download_directory/adult/`
+
+This feature ensures each *arr application only sees and processes its own downloads.
 
 ## TODO:
 - Better Error handling and retry behavior

--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -120,7 +120,13 @@ async fn recurse_download_targets(
     override_base_path: Option<String>,
     top_level: bool,
 ) -> Result<Vec<DownloadTarget>> {
-    let base_path = override_base_path.unwrap_or(app_data.config.download_directory.clone());
+    // Check if we have stored state for this transfer to get the correct download directory
+    let base_path = if override_base_path.is_some() {
+        override_base_path.unwrap()
+    } else {
+        // Try to get the download directory from state, fallback to default
+        app_data.state.get_download_dir_for_transfer(hash, &app_data.config.download_directory).await
+    };
     let mut targets = Vec::<DownloadTarget>::new();
     let response = putio::list_files(&app_data.config.putio.api_key, file_id).await?;
     let to = Path::new(&base_path)
@@ -255,6 +261,17 @@ pub async fn produce_transfers(app_data: Data<AppData>, tx: Sender<TransferMessa
                     continue;
                 }
                 let transfer = Transfer::from(app_data.clone(), putio_transfer);
+                
+                // Try to match with stored state if we don't have it
+                if let Some(hash) = &putio_transfer.hash {
+                    if app_data.state.get_transfer(hash).await.is_none() {
+                        // No stored state, try to determine category from current config
+                        // This handles transfers that existed before state tracking was implemented
+                        let category = "default".to_string();
+                        let download_dir = app_data.config.download_directory.clone();
+                        app_data.state.add_transfer(hash.clone(), category, download_dir).await.ok();
+                    }
+                }
 
                 info!("{}: ready for download", transfer);
                 tx.send(TransferMessage::QueuedForDownload(transfer))

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -2,7 +2,7 @@ use crate::{
     // downloader::DownloadStatus,
     services::putio::{self, PutIOTransfer},
     services::transmission::{TransmissionRequest, TransmissionTorrent},
-    AppData,
+    AppData, ArrConfig, Config,
 };
 use actix_web::web;
 use anyhow::Result;
@@ -13,11 +13,48 @@ use log::info;
 use magnet_url::Magnet;
 use serde_json::json;
 
+fn determine_category(download_dir: &str, config: &Config) -> String {
+    // Check if the download_dir matches any configured category
+    if let Some(sonarr) = &config.sonarr {
+        if let Some(category) = &sonarr.category {
+            if download_dir.contains(category) {
+                return category.clone();
+            }
+        }
+    }
+    if let Some(radarr) = &config.radarr {
+        if let Some(category) = &radarr.category {
+            if download_dir.contains(category) {
+                return category.clone();
+            }
+        }
+    }
+    if let Some(whisparr) = &config.whisparr {
+        if let Some(category) = &whisparr.category {
+            if download_dir.contains(category) {
+                return category.clone();
+            }
+        }
+    }
+    // Default category if none matched
+    "default".to_string()
+}
+
 pub(crate) async fn handle_torrent_add(
     api_token: &str,
     payload: &web::Json<TransmissionRequest>,
+    app_data: &web::Data<AppData>,
 ) -> Result<Option<serde_json::Value>> {
     let arguments = payload.arguments.as_ref().unwrap().as_object().unwrap();
+    
+    // Extract download-dir from the request to determine the category
+    let download_dir = arguments.get("download-dir")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&app_data.config.download_directory)
+        .to_string();
+    
+    // Determine which service sent this based on the download-dir
+    let category = determine_category(&download_dir, &app_data.config);
     if arguments.contains_key("metainfo") {
         // .torrent files
         let b64 = arguments["metainfo"].as_str().unwrap();
@@ -28,27 +65,66 @@ pub(crate) async fn handle_torrent_add(
 
         match Torrent::read_from_bytes(bytes) {
             Ok(t) => {
-                // let name = t.name;
+                // Store transfer state with the torrent hash
+                // When put.io processes this torrent, it will have the same hash
+                if let Ok(hash_bytes) = t.info_hash() {
+                    // Convert bytes to hex string manually
+                    let hash = hash_bytes.iter()
+                        .map(|byte| format!("{:02x}", byte))
+                        .collect::<String>();
+                    let full_download_dir = if category != "default" {
+                        format!("{}/{}", app_data.config.download_directory, category)
+                    } else {
+                        app_data.config.download_directory.clone()
+                    };
+                    app_data.state.add_transfer(
+                        hash.to_lowercase(),
+                        category.clone(),
+                        full_download_dir
+                    ).await?;
+                }
                 info!(
-                    "{}: torrent uploaded",
-                    format!("[ffff: {}]", t.name).magenta()
+                    "{}: torrent uploaded (category: {})",
+                    format!("[ffff: {}]", t.name).magenta(),
+                    category
                 );
             }
-            Err(_) => info!("New torrent uploaded"),
+            Err(_) => info!("New torrent uploaded (category: {})", category),
         };
     } else {
         // Magnet links
         let magnet_url = arguments["filename"].as_str().unwrap();
         putio::add_transfer(api_token, magnet_url).await?;
         match Magnet::new(magnet_url) {
-            Ok(m) if m.dn.is_some() => {
-                info!(
-                    "{}: magnet link uploaded",
-                    format!("[ffff: {}]", urldecode::decode(m.dn.unwrap())).magenta()
-                );
+            Ok(m) => {
+                // Store transfer state with hash from magnet
+                if let Some(xt) = m.xt {
+                    // Extract hash from xt (usually in format "urn:btih:HASH")
+                    if let Some(hash) = xt.strip_prefix("urn:btih:") {
+                        let full_download_dir = if category != "default" {
+                            format!("{}/{}", app_data.config.download_directory, category)
+                        } else {
+                            app_data.config.download_directory.clone()
+                        };
+                        app_data.state.add_transfer(
+                            hash.to_lowercase(), 
+                            category.clone(), 
+                            full_download_dir
+                        ).await?;
+                    }
+                }
+                if let Some(dn) = m.dn {
+                    info!(
+                        "{}: magnet link uploaded (category: {})",
+                        format!("[ffff: {}]", urldecode::decode(dn)).magenta(),
+                        category
+                    );
+                } else {
+                    info!("magnet link uploaded (category: {})", category);
+                }
             }
             _ => {
-                info!("unknown magnet link uploaded");
+                info!("unknown magnet link uploaded (category: {})", category);
             }
         }
     };
@@ -102,10 +178,21 @@ pub(crate) async fn handle_torrent_get(
 ) -> Option<serde_json::Value> {
     let transfers = putio::list_transfers(api_token).await.unwrap().transfers;
 
-    let transmission_transfers = transfers.into_iter().map(|t| async {
-        let mut tt: TransmissionTorrent = t.into();
-        tt.download_dir = app_data.config.download_directory.clone();
-        tt
+    let transmission_transfers = transfers.into_iter().map(|t| {
+        let app_data = app_data.clone();
+        async move {
+            let mut tt: TransmissionTorrent = t.clone().into();
+            // Get the correct download directory from state if available
+            if let Some(hash) = &t.hash {
+                tt.download_dir = app_data.state.get_download_dir_for_transfer(
+                    hash, 
+                    &app_data.config.download_directory
+                ).await;
+            } else {
+                tt.download_dir = app_data.config.download_directory.clone();
+            }
+            tt
+        }
     });
     let transmission_transfers: Vec<TransmissionTorrent> =
         futures::future::join_all(transmission_transfers).await;

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -40,7 +40,7 @@ pub(crate) async fn rpc_post(
         "torrent-set" => None, // Nothing to do here
         "queue-move-top" => None,
         "torrent-remove" => handle_torrent_remove(putio_api_token, &payload).await,
-        "torrent-add" => match handle_torrent_add(putio_api_token, &payload).await {
+        "torrent-add" => match handle_torrent_add(putio_api_token, &payload, &app_data).await {
             Ok(v) => v,
             Err(e) => {
                 error!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use utils::{generate_config, get_token};
 mod download_system;
 mod http;
 mod services;
+mod state;
 mod utils;
 
 /// put.io to sonarr/radarr proxy
@@ -69,10 +70,12 @@ pub struct PutioConfig {
 pub struct ArrConfig {
     url: String,
     api_key: String,
+    category: Option<String>,
 }
 
 pub struct AppData {
     pub config: Config,
+    pub state: state::StateManager,
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -122,6 +125,7 @@ async fn main() -> Result<()> {
 
             let app_data = web::Data::new(AppData {
                 config: config.clone(),
+                state: state::StateManager::new(),
             });
 
             match putio::account_info(&app_data.config.putio.api_key).await {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferState {
+    pub hash: String,
+    pub source_category: String,
+    pub download_dir: String,
+}
+
+#[derive(Clone)]
+pub struct StateManager {
+    transfers: Arc<RwLock<HashMap<String, TransferState>>>,
+}
+
+impl StateManager {
+    pub fn new() -> Self {
+        Self {
+            transfers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn add_transfer(&self, hash: String, category: String, download_dir: String) -> Result<()> {
+        let mut transfers = self.transfers.write().await;
+        transfers.insert(
+            hash.clone(),
+            TransferState {
+                hash,
+                source_category: category,
+                download_dir,
+            },
+        );
+        Ok(())
+    }
+
+    pub async fn get_transfer(&self, hash: &str) -> Option<TransferState> {
+        let transfers = self.transfers.read().await;
+        transfers.get(hash).cloned()
+    }
+
+    pub async fn remove_transfer(&self, hash: &str) -> Result<()> {
+        let mut transfers = self.transfers.write().await;
+        transfers.remove(hash);
+        Ok(())
+    }
+
+    pub async fn get_download_dir_for_transfer(&self, hash: &str, default_dir: &str) -> String {
+        if let Some(state) = self.get_transfer(hash).await {
+            state.download_dir
+        } else {
+            default_dir.to_string()
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,16 +48,25 @@ api_key =  "{putio_api_key}"
 url = "http://mysonarrhost:8989/sonarr"
 # Can be found in Settings -> General
 api_key = "MYSONARRAPIKEY"
+# Optional category/subdirectory for Sonarr downloads (e.g., "tv" or "shows")
+# This should match the category configured in Sonarr's download client settings
+category = "tv"
 
 [radarr]
 url = "http://myradarrhost:7878/radarr"
 # Can be found in Settings -> General
 api_key = "MYRADARRAPIKEY"
+# Optional category/subdirectory for Radarr downloads (e.g., "movies")
+# This should match the category configured in Radarr's download client settings
+category = "movies"
 
 [whisparr]
 url = "http://mywhisparrhost:6969/radarr"
 # Can be found in Settings -> General
 api_key = "MYWHISPARRAPIKEY"
+# Optional category/subdirectory for Whisparr downloads (e.g., "adult")
+# This should match the category configured in Whisparr's download client settings
+category = "adult"
 
 "#;
 


### PR DESCRIPTION
Add a state manager to track transfer hashes and their associated download paths. This allows the proxy to honor the "category" or "download-dir" specified by Sonarr, Radarr, and Whisparr, ensuring files are downloaded into service-specific sub-directories rather than a single global directory.