### PR TITLE
Fix: stripping the prefix from the magnet hash when not present

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -95,18 +95,18 @@ pub(crate) async fn handle_torrent_add(
                 // Store transfer state with hash from magnet
                 if let Some(xt) = m.xt {
                     // Extract hash from xt (usually in format "urn:btih:HASH")
-                    if let Some(hash) = xt.strip_prefix("urn:btih:") {
-                        let full_download_dir = if category != "default" {
-                            format!("{}/{}", app_data.config.download_directory, category)
-                        } else {
-                            app_data.config.download_directory.clone()
-                        };
-                        app_data.state.add_transfer(
-                            hash.to_lowercase(), 
-                            category.clone(), 
-                            full_download_dir
-                        ).await?;
-                    }
+                    // unless magnet_url::Magnet has already extracted it
+                    let hash = xt.strip_prefix("urn:btih:").unwrap_or(&xt);
+                    let full_download_dir = if category != "default" {
+                        format!("{}/{}", app_data.config.download_directory, category)
+                    } else {
+                        app_data.config.download_directory.clone()
+                    };
+                    app_data.state.add_transfer(
+                        hash.to_lowercase(),
+                        category.clone(),
+                        full_download_dir
+                    ).await?;
                 }
                 if let Some(dn) = m.dn {
                     info!(


### PR DESCRIPTION
Running version: 0.6.0 

Hi, thanks for the awesome project. I was testing the new radarr/sonarr category-support in the latest release and I noticed that the magnets sent by radarr/sonarr were failing to have their download folder changed according to their category.
 
I checked and I think the issue is that `magnet_url::Magnet` already strips the `xt` prefix so when we do it manually it fails, which returns `None`, so the code that sets the `download_dir` to be the category subdir is never called.

I've updated it so that it will try to strip the prefix and if it fails (because it's already been stripped by `magnet_url`) then it just returns the parsed `xt` unmodified.

I've tested it locally and it seems to work. I'm happy to make any suggested changes. Thanks again