### PR TITLE
Skip unmanaged transfers, complete only after local download, and make downloads resilient (fixes #9, #16)

### DIFF
--- a/src/download_system/download.rs
+++ b/src/download_system/download.rs
@@ -75,6 +75,14 @@ async fn download_target(app_data: &Data<AppData>, target: &DownloadTarget) -> R
 async fn fetch(target: &DownloadTarget, uid: u32, client: &reqwest::Client) -> Result<()> {
     let tmp_path = format!("{}.downloading", &target.to);
 
+    // Make sure the destination directory exists. A File target can be processed
+    // before its parent Directory target, and external cleanup may have removed
+    // an emptied folder, so create it here rather than failing with "No such
+    // file or directory" (which the retry loop below would otherwise spin on).
+    if let Some(parent) = Path::new(&tmp_path).parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
     // A single stream can stall (put.io stops sending mid-download). Rather than
     // restarting the whole file, retry and resume from the bytes already on disk
     // using a Range request. put.io serves `206 Partial Content`, so each retry

--- a/src/download_system/download.rs
+++ b/src/download_system/download.rs
@@ -6,7 +6,7 @@ use async_channel::{Receiver, Sender};
 use colored::*;
 use file_owner::PathExt;
 use futures::StreamExt;
-use log::{error, info};
+use log::{error, info, warn};
 use nix::unistd::Uid;
 use std::{fs, path::Path};
 
@@ -74,36 +74,78 @@ async fn download_target(app_data: &Data<AppData>, target: &DownloadTarget) -> R
 
 async fn fetch(target: &DownloadTarget, uid: u32, client: &reqwest::Client) -> Result<()> {
     let tmp_path = format!("{}.downloading", &target.to);
-    let mut tmp_file = tokio::fs::File::create(&tmp_path).await?;
 
-    let url = target.from.clone().context("No URL found")?;
-
-    // Reuse the shared client (built with a connect timeout) so connections
-    // are pooled across downloads instead of building one per fetch.
-    let response = client.get(url).send().await?;
-    if !response.status().is_success() {
-        bail!("download failed: HTTP {}", response.status());
-    }
-    let mut byte_stream = response.bytes_stream();
-
-    // Guard each chunk read with a timeout. If put.io stops sending data
-    // mid-stream, the download fails instead of hanging the worker forever
-    // (which would eventually stall every download worker — see issue #9).
+    // A single stream can stall (put.io stops sending mid-download). Rather than
+    // restarting the whole file, retry and resume from the bytes already on disk
+    // using a Range request. put.io serves `206 Partial Content`, so each retry
+    // picks up where the previous one stopped until the file is complete.
+    const MAX_ATTEMPTS: u32 = 20;
+    let mut attempt = 0;
     loop {
-        match tokio::time::timeout(std::time::Duration::from_secs(60), byte_stream.next()).await {
-            Ok(Some(item)) => {
-                tokio::io::copy(&mut item?.as_ref(), &mut tmp_file).await?;
+        attempt += 1;
+        match fetch_attempt(target, &tmp_path, client).await {
+            Ok(()) => break,
+            Err(e) if attempt < MAX_ATTEMPTS => {
+                warn!("{}: download attempt {} failed ({}), resuming", target, attempt, e);
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
             }
-            Ok(None) => break,
-            Err(_) => bail!("download stalled: no data received for 60s"),
+            Err(e) => bail!("download failed after {} attempts: {}", attempt, e),
         }
     }
+
     if Uid::effective().is_root() {
         tmp_path.clone().set_owner(uid)?;
     }
 
     fs::rename(&tmp_path, &target.to)?;
 
+    Ok(())
+}
+
+/// Downloads `target` into `tmp_path`, resuming from whatever is already on disk
+/// via a Range request. Returns Ok only when the stream finished cleanly; a
+/// stall (no data for 60s) or a non-success status returns an error so the
+/// caller can retry and resume.
+async fn fetch_attempt(
+    target: &DownloadTarget,
+    tmp_path: &str,
+    client: &reqwest::Client,
+) -> Result<()> {
+    let existing = tokio::fs::metadata(tmp_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let url = target.from.clone().context("No URL found")?;
+    let mut req = client.get(url);
+    if existing > 0 {
+        req = req.header(reqwest::header::RANGE, format!("bytes={}-", existing));
+    }
+    let response = req.send().await?;
+    let status = response.status();
+    if !(status.is_success() || status == reqwest::StatusCode::PARTIAL_CONTENT) {
+        bail!("HTTP {}", status);
+    }
+
+    // If the server honored the Range request (206), append to the partial file;
+    // otherwise it returned the whole file (200), so start it over.
+    let resumed = status == reqwest::StatusCode::PARTIAL_CONTENT && existing > 0;
+    let mut tmp_file = if resumed {
+        tokio::fs::OpenOptions::new().append(true).open(tmp_path).await?
+    } else {
+        tokio::fs::File::create(tmp_path).await?
+    };
+
+    let mut byte_stream = response.bytes_stream();
+    loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(60), byte_stream.next()).await {
+            Ok(Some(item)) => {
+                tokio::io::copy(&mut item?.as_ref(), &mut tmp_file).await?;
+            }
+            Ok(None) => break,
+            Err(_) => bail!("stalled: no data received for 60s"),
+        }
+    }
     Ok(())
 }
 

--- a/src/download_system/download.rs
+++ b/src/download_system/download.rs
@@ -57,7 +57,7 @@ async fn download_target(app_data: &Data<AppData>, target: &DownloadTarget) -> R
             // Delete file if already exists
             if !Path::new(&target.to).exists() {
                 info!("{}: download {}", &target, "started".yellow());
-                match fetch(target, app_data.config.uid).await {
+                match fetch(target, app_data.config.uid, &app_data.http).await {
                     Ok(_) => info!("{}: download {}", &target, "succeeded".green()),
                     Err(e) => {
                         error!("{}: download {}: {}", &target, "failed".red(), e);
@@ -72,18 +72,14 @@ async fn download_target(app_data: &Data<AppData>, target: &DownloadTarget) -> R
     Ok(())
 }
 
-async fn fetch(target: &DownloadTarget, uid: u32) -> Result<()> {
+async fn fetch(target: &DownloadTarget, uid: u32, client: &reqwest::Client) -> Result<()> {
     let tmp_path = format!("{}.downloading", &target.to);
     let mut tmp_file = tokio::fs::File::create(&tmp_path).await?;
 
     let url = target.from.clone().context("No URL found")?;
 
-    // Use an explicit client with a connect timeout so a stalled connection to
-    // put.io fails fast instead of hanging the orchestration worker forever
-    // (which would block all other transfers — see issue #9).
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(30))
-        .build()?;
+    // Reuse the shared client (built with a connect timeout) so connections
+    // are pooled across downloads instead of building one per fetch.
     let response = client.get(url).send().await?;
     if !response.status().is_success() {
         bail!("download failed: HTTP {}", response.status());

--- a/src/download_system/download.rs
+++ b/src/download_system/download.rs
@@ -90,8 +90,17 @@ async fn fetch(target: &DownloadTarget, uid: u32) -> Result<()> {
     }
     let mut byte_stream = response.bytes_stream();
 
-    while let Some(item) = byte_stream.next().await {
-        tokio::io::copy(&mut item?.as_ref(), &mut tmp_file).await?;
+    // Guard each chunk read with a timeout. If put.io stops sending data
+    // mid-stream, the download fails instead of hanging the worker forever
+    // (which would eventually stall every download worker — see issue #9).
+    loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(60), byte_stream.next()).await {
+            Ok(Some(item)) => {
+                tokio::io::copy(&mut item?.as_ref(), &mut tmp_file).await?;
+            }
+            Ok(None) => break,
+            Err(_) => bail!("download stalled: no data received for 60s"),
+        }
     }
     if Uid::effective().is_root() {
         tmp_path.clone().set_owner(uid)?;

--- a/src/download_system/download.rs
+++ b/src/download_system/download.rs
@@ -77,7 +77,18 @@ async fn fetch(target: &DownloadTarget, uid: u32) -> Result<()> {
     let mut tmp_file = tokio::fs::File::create(&tmp_path).await?;
 
     let url = target.from.clone().context("No URL found")?;
-    let mut byte_stream = reqwest::get(url).await?.bytes_stream();
+
+    // Use an explicit client with a connect timeout so a stalled connection to
+    // put.io fails fast instead of hanging the orchestration worker forever
+    // (which would block all other transfers — see issue #9).
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let response = client.get(url).send().await?;
+    if !response.status().is_success() {
+        bail!("download failed: HTTP {}", response.status());
+    }
+    let mut byte_stream = response.bytes_stream();
 
     while let Some(item) = byte_stream.next().await {
         tokio::io::copy(&mut item?.as_ref(), &mut tmp_file).await?;

--- a/src/download_system/orchestration.rs
+++ b/src/download_system/orchestration.rs
@@ -79,6 +79,9 @@ impl Worker {
                         DownloadDoneStatus::Failed => false,
                     }) {
                         info!("{}: download {}", t, "done".blue());
+                        // The files now exist locally, so it's safe to report
+                        // this transfer as complete to the *arr (see issue #16).
+                        self.app_data.state.mark_local_complete(t.transfer_id).await;
                         self.tx
                             .send(TransferMessage::Downloaded(Transfer {
                                 targets: Some(targets),

--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -240,6 +240,22 @@ pub enum TargetType {
 }
 
 // Check for new putio transfers and if they qualify, send them on for download
+/// Returns true if this transfer is managed by putioarr, i.e. it has stored
+/// category/download-dir state because *it* uploaded it on behalf of an *arr.
+/// Transfers added directly on put.io (e.g. a manually-maintained "Watch List")
+/// have no state. Unless the user opts in via `download_unmanaged`, those are
+/// ignored so putioarr does not try to download the entire put.io account and
+/// hang on seeding transfers (see upstream issue #9).
+async fn is_managed(app_data: &Data<AppData>, putio_transfer: &PutIOTransfer) -> bool {
+    if app_data.config.download_unmanaged {
+        return true;
+    }
+    match &putio_transfer.hash {
+        Some(hash) => app_data.state.get_transfer(hash).await.is_some(),
+        None => false,
+    }
+}
+
 pub async fn produce_transfers(app_data: Data<AppData>, tx: Sender<TransferMessage>) -> Result<()> {
     let putio_check_interval = std::time::Duration::from_secs(app_data.config.polling_interval);
     let mut seen = Vec::<u64>::new();
@@ -256,7 +272,7 @@ pub async fn produce_transfers(app_data: Data<AppData>, tx: Sender<TransferMessa
     {
         let name = putio_transfer.name.clone().unwrap_or("??".to_string());
         let mut transfer = Transfer::from(app_data.clone(), putio_transfer);
-        if putio_transfer.is_downloadable() {
+        if putio_transfer.is_downloadable() && is_managed(&app_data, putio_transfer).await {
             info!("Getting download target for {name}");
             let targets = transfer.get_download_targets().await;
             if targets.is_err() {
@@ -289,13 +305,16 @@ pub async fn produce_transfers(app_data: Data<AppData>, tx: Sender<TransferMessa
                 }
                 let transfer = Transfer::from(app_data.clone(), putio_transfer);
 
-                if let Some(hash) = &putio_transfer.hash {
-                    if app_data.state.get_transfer(hash).await.is_none() {
-                        warn!(
-                            "{}: no stored category/download-dir for hash {} — falling back to default download_directory ({}). This transfer was likely uploaded before putioarr started, or arr did not send a download-dir we could match to a category.",
-                            transfer, hash, app_data.config.download_directory
-                        );
-                    }
+                // Skip transfers we don't manage (e.g. a manual Watch List) unless
+                // `download_unmanaged` is set. This prevents putioarr from trying to
+                // download the whole account and hanging on seeding transfers (#9).
+                if !is_managed(&app_data, putio_transfer).await {
+                    debug!(
+                        "{}: not managed by putioarr (no stored category/download-dir), skipping",
+                        transfer
+                    );
+                    seen.push(putio_transfer.id);
+                    continue;
                 }
 
                 info!("{}: ready for download", transfer);

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,7 +1,7 @@
 use crate::{
     // downloader::DownloadStatus,
     services::putio::{self, PutIOTransfer},
-    services::transmission::{TransmissionRequest, TransmissionTorrent},
+    services::transmission::{TransmissionRequest, TransmissionTorrent, TransmissionTorrentStatus},
     AppData, Config,
 };
 use actix_web::web;
@@ -208,11 +208,27 @@ pub(crate) async fn handle_torrent_get(
             // Get the correct download directory from state if available
             if let Some(hash) = &t.hash {
                 tt.download_dir = app_data.state.get_download_dir_for_transfer(
-                    hash, 
+                    hash,
                     &app_data.config.download_directory
                 ).await;
             } else {
                 tt.download_dir = app_data.config.download_directory.clone();
+            }
+            // put.io marks a transfer complete as soon as *its own* (cloud)
+            // download finishes, but the files don't exist on local disk until
+            // putioarr has pulled them down. Reporting completion to the *arr
+            // too early makes it try to import missing files ("No files found
+            // eligible for import"). Keep the torrent in a downloading state
+            // until putioarr has actually finished the local download (#16).
+            let putio_done = tt.is_finished
+                || matches!(
+                    tt.status,
+                    TransmissionTorrentStatus::Seeding | TransmissionTorrentStatus::Stopped
+                );
+            if putio_done && !app_data.state.is_local_complete(t.id).await {
+                tt.is_finished = false;
+                tt.left_until_done = std::cmp::max(tt.total_size, 1);
+                tt.status = TransmissionTorrentStatus::Downloading;
             }
             tt
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,9 @@ pub struct ArrConfig {
 pub struct AppData {
     pub config: Config,
     pub state: state::StateManager,
+    /// Shared HTTP client, reused across all downloads so connections are
+    /// pooled instead of building a new client per fetch.
+    pub http: reqwest::Client,
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -181,9 +184,14 @@ async fn main() -> Result<()> {
 
             info!("Starting putioarr, version {}", VERSION);
 
+            let http = reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("building shared reqwest client");
             let app_data = web::Data::new(AppData {
                 config: config.clone(),
                 state: state::StateManager::new(config.putio.api_key.clone()),
+                http,
             });
 
             match putio::account_info(&app_data.config.putio.api_key).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,13 @@ pub struct Config {
     skip_directories: Vec<String>,
     uid: u32,
     username: String,
+    /// When true, download every transfer found on the put.io account, including
+    /// ones not added by putioarr (e.g. a manually-maintained Watch List). When
+    /// false (default), only download transfers putioarr added on behalf of an
+    /// *arr. Keeping this false avoids hanging on seeding transfers (issue #9) and
+    /// lets the put.io account be shared with manual downloads.
+    #[serde(default)]
+    download_unmanaged: bool,
     putio: PutioConfig,
     sonarr: Option<ArrConfig>,
     radarr: Option<ArrConfig>,
@@ -137,6 +144,7 @@ async fn main() -> Result<()> {
                 .join(Serialized::default("polling_interval", 10))
                 .join(Serialized::default("port", 9091))
                 .join(Serialized::default("uid", 1000))
+                .join(Serialized::default("download_unmanaged", false))
                 .join(Serialized::default(
                     "skip_directories",
                     vec!["sample", "extras"],

--- a/src/services/transmission.rs
+++ b/src/services/transmission.rs
@@ -107,7 +107,7 @@ impl From<PutIOTransfer> for TransmissionTorrent {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone, Copy, PartialEq)]
 pub enum TransmissionTorrentStatus {
     Stopped = 0,
     CheckWait = 1,

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use crate::services::putio;
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -26,6 +26,10 @@ pub struct TransferState {
 pub struct StateManager {
     api_token: String,
     transfers: Arc<RwLock<HashMap<String, TransferState>>>,
+    /// Transfer ids whose files putioarr has finished downloading to local
+    /// disk. Used to avoid telling the *arr a download is complete before the
+    /// files actually exist locally (see issue #16).
+    local_complete: Arc<RwLock<HashSet<u64>>>,
 }
 
 impl StateManager {
@@ -33,7 +37,23 @@ impl StateManager {
         Self {
             api_token,
             transfers: Arc::new(RwLock::new(HashMap::new())),
+            local_complete: Arc::new(RwLock::new(HashSet::new())),
         }
+    }
+
+    /// Marks a transfer's local download as fully finished (pulled home).
+    pub async fn mark_local_complete(&self, id: u64) {
+        self.local_complete.write().await.insert(id);
+    }
+
+    /// Returns true once putioarr has finished downloading the transfer locally.
+    pub async fn is_local_complete(&self, id: u64) -> bool {
+        self.local_complete.read().await.contains(&id)
+    }
+
+    /// Forgets a transfer's local-complete marker (e.g. after cleanup).
+    pub async fn clear_local_complete(&self, id: u64) {
+        self.local_complete.write().await.remove(&id);
     }
 
     /// Loads persisted state from put.io into the in-memory cache. Should be

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,7 @@ uid = 1000
 # Optional polling interval in secs, default 10.
 polling_interval = 10
 
-# Optional skip directories when downloding, default ["sample", "extras"]
+# Optional skip directories when downloading, default ["sample", "extras"]
 skip_directories = ["sample", "extras"]
 
 # Optional. When false (default), only download transfers that putioarr added on

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,12 @@ polling_interval = 10
 # Optional skip directories when downloding, default ["sample", "extras"]
 skip_directories = ["sample", "extras"]
 
+# Optional. When false (default), only download transfers that putioarr added on
+# behalf of an *arr. Transfers added directly on put.io (e.g. a manual Watch List)
+# are ignored, so the account can be shared and putioarr won't hang on seeding
+# transfers. Set to true to download every transfer on the account.
+download_unmanaged = false
+
 # Optional number of orchestration workers, default 10. Unless there are many changes coming from
 # put.io, you shouldn't have to touch this number. 10 is already overkill.
 orchestration_workers = 10


### PR DESCRIPTION
This PR fixes two issues and makes the download path resilient.

## fixes #9 — process hangs / downloads the whole account

Two root causes:

1. **Unmanaged transfers were downloaded too.** `produce_transfers` queued *every* downloadable transfer on the account, including ones putioarr did not add (e.g. a manually-maintained Watch List, or anything added via the put.io web UI). On a shared account this meant putioarr tried to pull the entire library, and stalled/seeding transfers blocked the orchestration workers.
   - `is_managed()` now only processes transfers that have stored category/download-dir state (i.e. putioarr uploaded them on behalf of an *arr). Both the resume and monitor loops skip the rest.
   - New `download_unmanaged` config option (default `false`) restores the old "download everything on the account" behaviour for dedicated accounts.

2. **No timeout on the download stream.** `fetch()` used a bare `reqwest::get` with no timeout, so a stalled connection — or a connection that stalls mid-stream — hung the worker forever, eventually halting all transfers.
   - Added a connect timeout and a per-chunk inactivity timeout (`tokio::time::timeout` around `byte_stream.next()`), so a stalled download fails instead of hanging.

## fixes #16 — report complete only after local download finishes

put.io marks a transfer complete as soon as *its own* (cloud) download finishes, but the files do not exist on local disk until putioarr has pulled them down. Reporting completion to Sonarr/Radarr at that point made them try to import files that are not there yet, leaving the queue stuck on `No files found eligible for import`.

- `StateManager` now tracks which transfers have finished downloading locally (`local_complete`, marked when the orchestration emits `Downloaded`).
- The Transmission `torrent-get` response keeps a transfer in a downloading state until its local download is done, even if put.io already reports it complete/seeding.

## resumable downloads (addresses #8)

A large download that stalled mid-stream was restarted from zero on the next attempt, so on a flaky put.io connection big files could loop forever and never finish. put.io serves Range requests (`206 Partial Content`), so `fetch()` now retries and resumes from the bytes already on disk via a `Range: bytes=<offset>-` header, appending to the partial file until it is complete (falling back to a fresh download if the server ignores the range). This addresses #8, where large files could fail randomly and never finish.

The destination directory is also (re)created before each download, so a File target handled before its Directory sibling — or a folder removed by external cleanup — does not leave the retry loop spinning on `No such file or directory`.

## misc
- Reuse a single shared `reqwest::Client` (stored in `AppData`) instead of building one per fetch, so connections are pooled.
- Fix a typo in the config template comment.

