### PR TITLE
Report the put.io file/folder name to the *arr, not the transfer name (fixes #20, #11)

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -12,6 +12,7 @@ use lava_torrent::torrent::v1::Torrent;
 use log::{error, info, warn};
 use magnet_url::Magnet;
 use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 fn determine_category(download_dir: &str, config: &Config) -> String {
@@ -201,6 +202,12 @@ pub(crate) async fn handle_torrent_get(
             Vec::new()
         }
     };
+
+    // Keep the file-name cache bounded to the transfers currently on the
+    // account, dropping cached entries for transfers that no longer exist so it
+    // doesn't grow without limit over the lifetime of the process.
+    let active_file_ids: HashSet<i64> = transfers.iter().filter_map(|t| t.file_id).collect();
+    app_data.state.retain_file_names(&active_file_ids).await;
 
     // Allocate the token once and share it cheaply (refcount bump) with each
     // per-transfer task, rather than allocating a new String per transfer.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -203,6 +203,7 @@ pub(crate) async fn handle_torrent_get(
 
     let transmission_transfers = transfers.into_iter().map(|t| {
         let app_data = app_data.clone();
+        let api_token = api_token.to_string();
         async move {
             let mut tt: TransmissionTorrent = t.clone().into();
             // Get the correct download directory from state if available
@@ -213,6 +214,29 @@ pub(crate) async fn handle_torrent_get(
                 ).await;
             } else {
                 tt.download_dir = app_data.config.download_directory.clone();
+            }
+            // put.io's transfer name often differs from the actual downloaded
+            // file/folder name (e.g. an indexer prefix like "www.foo.org - "),
+            // but the *arr locates the download at <download_dir>/<name>. Report
+            // the real put.io file/folder name (the one we download into) so the
+            // import doesn't fail with "No files found eligible for import" (#20).
+            if let Some(file_id) = t.file_id {
+                let resolved = match app_data.state.get_file_name(file_id).await {
+                    Some(name) => Some(name),
+                    None => match putio::list_files(&api_token, file_id).await {
+                        Ok(r) => {
+                            app_data.state.set_file_name(file_id, r.parent.name.clone()).await;
+                            Some(r.parent.name)
+                        }
+                        Err(e) => {
+                            warn!("Could not resolve put.io file name for {}: {}", file_id, e);
+                            None
+                        }
+                    },
+                };
+                if let Some(name) = resolved {
+                    tt.name = name;
+                }
             }
             // put.io marks a transfer complete as soon as *its own* (cloud)
             // download finishes, but the files don't exist on local disk until

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -234,12 +234,16 @@ pub(crate) async fn handle_torrent_get(
             if let Some(file_id) = t.file_id {
                 let resolved = match app_data.state.get_file_name(file_id).await {
                     Some(name) => Some(name),
+                    // Don't re-hit the API for a lookup that recently failed
+                    // (e.g. a file removed from put.io); retry only after a TTL.
+                    None if app_data.state.name_lookup_suppressed(file_id).await => None,
                     None => match putio::list_files(&api_token, file_id).await {
                         Ok(r) => {
                             app_data.state.set_file_name(file_id, r.parent.name.clone()).await;
                             Some(r.parent.name)
                         }
                         Err(e) => {
+                            app_data.state.mark_name_failed(file_id).await;
                             warn!("Could not resolve put.io file name for {}: {}", file_id, e);
                             None
                         }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -12,6 +12,7 @@ use lava_torrent::torrent::v1::Torrent;
 use log::{error, info, warn};
 use magnet_url::Magnet;
 use serde_json::json;
+use std::sync::Arc;
 
 fn determine_category(download_dir: &str, config: &Config) -> String {
     let arrs = config.all_arrs();
@@ -201,9 +202,12 @@ pub(crate) async fn handle_torrent_get(
         }
     };
 
+    // Allocate the token once and share it cheaply (refcount bump) with each
+    // per-transfer task, rather than allocating a new String per transfer.
+    let api_token: Arc<str> = Arc::from(api_token);
     let transmission_transfers = transfers.into_iter().map(|t| {
         let app_data = app_data.clone();
-        let api_token = api_token.to_string();
+        let api_token = Arc::clone(&api_token);
         async move {
             let mut tt: TransmissionTorrent = t.clone().into();
             // Get the correct download directory from state if available

--- a/src/state.rs
+++ b/src/state.rs
@@ -58,6 +58,13 @@ impl StateManager {
         self.file_names.write().await.insert(file_id, name);
     }
 
+    /// Drops cached file names for any `file_id` not in `keep`, so the cache
+    /// stays bounded to the transfers currently on the account instead of
+    /// growing without limit over the lifetime of the process.
+    pub async fn retain_file_names(&self, keep: &HashSet<i64>) {
+        self.file_names.write().await.retain(|id, _| keep.contains(id));
+    }
+
     /// Marks a transfer's local download as fully finished (pulled home).
     pub async fn mark_local_complete(&self, id: u64) {
         self.local_complete.write().await.insert(id);

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 /// Key under which putioarr stores its transfer state in put.io's per-user
@@ -36,6 +37,11 @@ pub struct StateManager {
     /// locate the download (see issue #20). A file_id's name never changes once
     /// downloaded, so caching it avoids an API call on every torrent-get.
     file_names: Arc<RwLock<HashMap<i64, String>>>,
+    /// Negative cache of `file_id`s whose name lookup failed, with the time of
+    /// the last attempt. A file may have been removed from put.io (a persistent
+    /// 404); without this, every torrent-get would re-hit the API and re-log a
+    /// warning. Retries are suppressed until [`Self::NAME_FAILURE_TTL`] passes.
+    failed_names: Arc<RwLock<HashMap<i64, Instant>>>,
 }
 
 impl StateManager {
@@ -45,24 +51,45 @@ impl StateManager {
             transfers: Arc::new(RwLock::new(HashMap::new())),
             local_complete: Arc::new(RwLock::new(HashSet::new())),
             file_names: Arc::new(RwLock::new(HashMap::new())),
+            failed_names: Arc::new(RwLock::new(HashMap::new())),
         }
     }
+
+    /// How long to suppress retrying a failed file-name lookup.
+    const NAME_FAILURE_TTL: Duration = Duration::from_secs(600);
 
     /// Returns the cached put.io file/folder name for a `file_id`, if known.
     pub async fn get_file_name(&self, file_id: i64) -> Option<String> {
         self.file_names.read().await.get(&file_id).cloned()
     }
 
-    /// Caches the put.io file/folder name for a `file_id`.
+    /// Caches the put.io file/folder name for a `file_id` and clears any prior
+    /// failure recorded for it.
     pub async fn set_file_name(&self, file_id: i64, name: String) {
         self.file_names.write().await.insert(file_id, name);
+        self.failed_names.write().await.remove(&file_id);
     }
 
-    /// Drops cached file names for any `file_id` not in `keep`, so the cache
-    /// stays bounded to the transfers currently on the account instead of
-    /// growing without limit over the lifetime of the process.
+    /// Records that resolving the name for `file_id` just failed.
+    pub async fn mark_name_failed(&self, file_id: i64) {
+        self.failed_names.write().await.insert(file_id, Instant::now());
+    }
+
+    /// Returns true if `file_id`'s name lookup failed recently and shouldn't be
+    /// retried yet, avoiding repeated API calls/warnings for persistent errors.
+    pub async fn name_lookup_suppressed(&self, file_id: i64) -> bool {
+        match self.failed_names.read().await.get(&file_id) {
+            Some(at) => at.elapsed() < Self::NAME_FAILURE_TTL,
+            None => false,
+        }
+    }
+
+    /// Drops cached file names (and failure markers) for any `file_id` not in
+    /// `keep`, so the caches stay bounded to the transfers currently on the
+    /// account instead of growing without limit over the lifetime of the process.
     pub async fn retain_file_names(&self, keep: &HashSet<i64>) {
         self.file_names.write().await.retain(|id, _| keep.contains(id));
+        self.failed_names.write().await.retain(|id, _| keep.contains(id));
     }
 
     /// Marks a transfer's local download as fully finished (pulled home).

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,6 +30,12 @@ pub struct StateManager {
     /// disk. Used to avoid telling the *arr a download is complete before the
     /// files actually exist locally (see issue #16).
     local_complete: Arc<RwLock<HashSet<u64>>>,
+    /// Caches the actual put.io file/folder name for a transfer's `file_id`.
+    /// put.io's transfer name often differs from the downloaded file/folder name
+    /// (e.g. an indexer prefix), and we report the latter to the *arr so it can
+    /// locate the download (see issue #20). A file_id's name never changes once
+    /// downloaded, so caching it avoids an API call on every torrent-get.
+    file_names: Arc<RwLock<HashMap<i64, String>>>,
 }
 
 impl StateManager {
@@ -38,7 +44,18 @@ impl StateManager {
             api_token,
             transfers: Arc::new(RwLock::new(HashMap::new())),
             local_complete: Arc::new(RwLock::new(HashSet::new())),
+            file_names: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Returns the cached put.io file/folder name for a `file_id`, if known.
+    pub async fn get_file_name(&self, file_id: i64) -> Option<String> {
+        self.file_names.read().await.get(&file_id).cloned()
+    }
+
+    /// Caches the put.io file/folder name for a `file_id`.
+    pub async fn set_file_name(&self, file_id: i64, name: String) {
+        self.file_names.write().await.insert(file_id, name);
     }
 
     /// Marks a transfer's local download as fully finished (pulled home).


### PR DESCRIPTION
Fixes #20. Also fixes #11 (downloads inside a folder, e.g. TV-show seasons, not being found by Sonarr) — it has the same root cause: the name reported to the *arr did not match the folder put.io actually created on disk.

## Problem

put.io's transfer name frequently differs from the name of the file or folder it produces. Indexers often prefix the torrent/transfer name (e.g. `www.example.org    -    Some.Movie.2011.1080p.BluRay-GROUP`), while the folder put.io actually creates is just `Some.Movie.2011.1080p.BluRay-GROUP`.

putioarr downloads into the real file/folder name, but reported the **transfer name** to Sonarr/Radarr in the Transmission `torrent-get` response. Since the *arr locates a completed download at `<download_dir>/<name>`, it looked in a path that does not exist and failed every such import with:

```
No files found are eligible for import in /downloads/movies/www.example.org    -    Some.Movie...
```

This silently breaks imports for any indexer that rewrites the transfer name — a large share of public-tracker releases.

## Fix

Resolve the transfer's `file_id` to its actual put.io file/folder name (the same name `recurse_download_targets` downloads into) and report that as the Transmission torrent `name`, so the *arr looks in the correct place.

The resolved name is cached per `file_id` in `StateManager` (a `file_id`'s name never changes once downloaded), so this does not add an API call on every `torrent-get`. If the file can't be resolved (e.g. it was already removed from put.io) it falls back to the transfer name.

## Testing

Ran against a live put.io account feeding Radarr/Sonarr. Before: ~12 transfers with indexer-prefixed names stuck permanently in `importPending` with "No files found are eligible for import". After deploying this change the reported `outputPath` for those transfers changed from the prefixed transfer name to the real folder name, and all of them imported successfully (stuck count went 12 → 0, NAS writes resumed at full speed).
