### PR TITLE
Handle put.io WAITING transfer status (fixes #12)

### DIFF
--- a/src/services/transmission.rs
+++ b/src/services/transmission.rs
@@ -122,7 +122,7 @@ impl From<String> for TransmissionTorrentStatus {
     fn from(value: String) -> Self {
         match value.to_uppercase().as_str() {
             "STOPPED" | "COMPLETED" | "ERROR" => Self::Stopped,
-            "CHECKWAIT" | "PREPARING_DOWNLOAD" => Self::CheckWait,
+            "CHECKWAIT" | "PREPARING_DOWNLOAD" | "WAITING" => Self::CheckWait,
             "CHECK" | "COMPLETING" => Self::Check,
             "QUEUED" | "IN_QUEUE" => Self::Queued,
             "DOWNLOADING" => Self::Downloading,


### PR DESCRIPTION
Fixes #12.

put.io reports a `WAITING` status for transfers that are queued/waiting before download. It was not in the `TransmissionTorrentStatus::from` match, so it fell through to the catch-all arm and logged:

```
Status WAITING unknown. Treating as CheckWait.
```

repeatedly (once per occurrence, on every poll), which is the log spam reported in the issue.

This maps `WAITING` explicitly to `CheckWait` — the same status the catch-all was already coercing it to, so there is no behavioural change — and the warning is no longer emitted for it. Genuinely unknown statuses still hit the catch-all and warn.