### PR TITLE
Throttle repeated *arr history-error logs (fixes #21)

### DIFF
--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -56,8 +56,9 @@ impl Transfer {
                     Err(e) => {
                         // A misconfigured/unreachable *arr fails for every
                         // transfer on every poll; throttle the log so it doesn't
-                        // fill the disk over time (issue #21).
-                        if self.app_data.state.should_log_arr_error(&app.to_string()).await {
+                        // fill the disk over time (issue #21). Key on the app's
+                        // existing name (no allocation on the suppressed path).
+                        if self.app_data.state.should_log_arr_error(&app.name).await {
                             error!(
                                 "Error retrieving history from {} (suppressing repeats for 5m): {}",
                                 app, e

--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -60,8 +60,10 @@ impl Transfer {
                         // existing name (no allocation on the suppressed path).
                         if self.app_data.state.should_log_arr_error(&app.name).await {
                             error!(
-                                "Error retrieving history from {} (suppressing repeats for 5m): {}",
-                                app, e
+                                "Error retrieving history from {} (suppressing repeats for {:?}): {}",
+                                app,
+                                crate::state::StateManager::ARR_ERROR_LOG_INTERVAL,
+                                e
                             );
                         }
                         false

--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -54,7 +54,15 @@ impl Transfer {
                 let service_result = match app.check_imported(&target.to).await {
                     Ok(r) => r,
                     Err(e) => {
-                        error!("Error retrieving history from {}: {}", app, e);
+                        // A misconfigured/unreachable *arr fails for every
+                        // transfer on every poll; throttle the log so it doesn't
+                        // fill the disk over time (issue #21).
+                        if self.app_data.state.should_log_arr_error(&app.to_string()).await {
+                            error!(
+                                "Error retrieving history from {} (suppressing repeats for 5m): {}",
+                                app, e
+                            );
+                        }
                         false
                     }
                 };

--- a/src/state.rs
+++ b/src/state.rs
@@ -58,7 +58,7 @@ impl StateManager {
         let mut map = self.arr_error_logged.write().await;
         let now = Instant::now();
         match map.get(app) {
-            Some(at) if now.duration_since(*at) < Self::ARR_ERROR_LOG_INTERVAL => false,
+            Some(at) if now.saturating_duration_since(*at) < Self::ARR_ERROR_LOG_INTERVAL => false,
             _ => {
                 map.insert(app.to_string(), now);
                 true

--- a/src/state.rs
+++ b/src/state.rs
@@ -48,7 +48,7 @@ impl StateManager {
     }
 
     /// Minimum time between logging the same *arr's connection error.
-    const ARR_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(300);
+    pub const ARR_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(300);
 
     /// Returns true if an error for `app` should be logged now, throttling
     /// repeats to at most one per [`Self::ARR_ERROR_LOG_INTERVAL`]. Keeps a

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 /// Key under which putioarr stores its transfer state in put.io's per-user
@@ -30,6 +31,10 @@ pub struct StateManager {
     /// disk. Used to avoid telling the *arr a download is complete before the
     /// files actually exist locally (see issue #16).
     local_complete: Arc<RwLock<HashSet<u64>>>,
+    /// Last time a connection error was logged for each *arr, used to throttle
+    /// the log. A misconfigured Sonarr/Radarr fails on every poll for every
+    /// transfer, and logging each one filled users' disks over time (issue #21).
+    arr_error_logged: Arc<RwLock<HashMap<String, Instant>>>,
 }
 
 impl StateManager {
@@ -38,6 +43,26 @@ impl StateManager {
             api_token,
             transfers: Arc::new(RwLock::new(HashMap::new())),
             local_complete: Arc::new(RwLock::new(HashSet::new())),
+            arr_error_logged: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Minimum time between logging the same *arr's connection error.
+    const ARR_ERROR_LOG_INTERVAL: Duration = Duration::from_secs(300);
+
+    /// Returns true if an error for `app` should be logged now, throttling
+    /// repeats to at most one per [`Self::ARR_ERROR_LOG_INTERVAL`]. Keeps a
+    /// persistently unreachable/misconfigured *arr from filling the disk with
+    /// identical error lines on every poll (issue #21).
+    pub async fn should_log_arr_error(&self, app: &str) -> bool {
+        let mut map = self.arr_error_logged.write().await;
+        let now = Instant::now();
+        match map.get(app) {
+            Some(at) if now.duration_since(*at) < Self::ARR_ERROR_LOG_INTERVAL => false,
+            _ => {
+                map.insert(app.to_string(), now);
+                true
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #21.

When a Sonarr/Radarr instance is misconfigured or unreachable, `is_imported` fails its history lookup for **every transfer on every poll**, and each failure logged:

```
ERROR Error retrieving history from Radarr: error decoding response body
```

With a 10s poll and any number of transfers that is a continuous stream of identical lines. The reporter saw it grow to ~23 GB and fill a 50 GB disk over a couple of months.

This throttles that specific error to at most once per 5 minutes per *arr (tracked in `StateManager`). The problem is still visible in the logs, but it can no longer grow without bound. Functional behaviour is unchanged — only the logging is rate-limited.

(A docker `logging: max-size` is a good defence-in-depth too, but this stops the root cause of the growth.)