### PR TITLE
Bound watch_for_import so stuck transfers can't stall downloads (fixes #30)

### DIFF
--- a/src/download_system/orchestration.rs
+++ b/src/download_system/orchestration.rs
@@ -144,6 +144,7 @@ async fn watch_for_import(
             let m = transfer.clone();
             tx.send(TransferMessage::Imported(m)).await?;
 
+            info!("{}: removed", transfer);
             break;
         }
         if started.elapsed() > MAX_IMPORT_WAIT {
@@ -157,7 +158,6 @@ async fn watch_for_import(
         }
         sleep(Duration::from_secs(app_data.config.polling_interval)).await;
     }
-    info!("{}: removed", transfer);
     Ok(())
 }
 

--- a/src/download_system/orchestration.rs
+++ b/src/download_system/orchestration.rs
@@ -11,10 +11,21 @@ use anyhow::Result;
 use async_channel::{Receiver, Sender};
 use colored::*;
 use log::{info, warn};
-use std::{fs, time::Duration};
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
 use tokio::{fs::metadata, time::sleep};
 
 use super::transfer::TransferMessage;
+
+/// How long to keep polling for a transfer to be imported before giving up.
+/// `is_imported()` requires *every* video file to be imported, but a transfer
+/// can contain a file the *arr will never import (e.g. a sample outside a
+/// `skip_directories` folder), which would otherwise make `watch_for_import`
+/// loop forever and accumulate until the process stalls (see issue #30).
+/// Genuine imports complete within a poll or two, so this bound is generous.
+const MAX_IMPORT_WAIT: Duration = Duration::from_secs(2 * 60 * 60);
 
 #[derive(Clone)]
 pub struct Worker {
@@ -111,6 +122,7 @@ async fn watch_for_import(
     transfer: Transfer,
 ) -> Result<()> {
     info!("{}: watching imports", transfer);
+    let started = Instant::now();
     loop {
         if transfer.is_imported().await {
             info!("{}: imported", transfer);
@@ -132,6 +144,15 @@ async fn watch_for_import(
             let m = transfer.clone();
             tx.send(TransferMessage::Imported(m)).await?;
 
+            break;
+        }
+        if started.elapsed() > MAX_IMPORT_WAIT {
+            warn!(
+                "{}: still not imported after {:?}; giving up watching. It likely contains a \
+                 file the *arr won't import (e.g. a sample outside a skip_directories folder), \
+                 so its local/put.io copies won't be cleaned up automatically.",
+                transfer, MAX_IMPORT_WAIT
+            );
             break;
         }
         sleep(Duration::from_secs(app_data.config.polling_interval)).await;

--- a/src/download_system/orchestration.rs
+++ b/src/download_system/orchestration.rs
@@ -19,14 +19,6 @@ use tokio::{fs::metadata, time::sleep};
 
 use super::transfer::TransferMessage;
 
-/// How long to keep polling for a transfer to be imported before giving up.
-/// `is_imported()` requires *every* video file to be imported, but a transfer
-/// can contain a file the *arr will never import (e.g. a sample outside a
-/// `skip_directories` folder), which would otherwise make `watch_for_import`
-/// loop forever and accumulate until the process stalls (see issue #30).
-/// Genuine imports complete within a poll or two, so this bound is generous.
-const MAX_IMPORT_WAIT: Duration = Duration::from_secs(2 * 60 * 60);
-
 #[derive(Clone)]
 pub struct Worker {
     _id: usize,
@@ -122,6 +114,11 @@ async fn watch_for_import(
     transfer: Transfer,
 ) -> Result<()> {
     info!("{}: watching imports", transfer);
+    // Give up watching after this long so a transfer that never fully imports
+    // (e.g. one containing a sample the *arr won't import) can't loop forever
+    // and accumulate until downloads stall (see issue #30). Genuine imports are
+    // detected within a poll or two, so the default is generous.
+    let import_timeout = Duration::from_secs(app_data.config.import_timeout_secs);
     let started = Instant::now();
     loop {
         if transfer.is_imported().await {
@@ -147,12 +144,12 @@ async fn watch_for_import(
             info!("{}: removed", transfer);
             break;
         }
-        if started.elapsed() > MAX_IMPORT_WAIT {
+        if app_data.config.import_timeout_secs > 0 && started.elapsed() > import_timeout {
             warn!(
                 "{}: still not imported after {:?}; giving up watching. It likely contains a \
                  file the *arr won't import (e.g. a sample outside a skip_directories folder), \
                  so its local/put.io copies won't be cleaned up automatically.",
-                transfer, MAX_IMPORT_WAIT
+                transfer, import_timeout
             );
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,12 @@ pub struct Config {
     orchestration_workers: usize,
     password: String,
     polling_interval: u64,
+    /// How long (seconds) to keep polling for a transfer to be imported before
+    /// giving up watching it. Bounds the per-transfer import-watch loop so a
+    /// transfer that never fully imports (e.g. one with a sample the *arr won't
+    /// import) can't accumulate and stall downloads. Default 7200 (2h).
+    #[serde(default)]
+    import_timeout_secs: u64,
     port: u16,
     skip_directories: Vec<String>,
     uid: u32,
@@ -145,6 +151,7 @@ async fn main() -> Result<()> {
                 .join(Serialized::default("orchestration_workers", 10))
                 .join(Serialized::default("loglevel", "info"))
                 .join(Serialized::default("polling_interval", 10))
+                .join(Serialized::default("import_timeout_secs", 7200u64))
                 .join(Serialized::default("port", 9091))
                 .join(Serialized::default("uid", 1000))
                 .join(Serialized::default("download_unmanaged", false))

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ struct RunArgs {
     pub config_path: String,
 }
 
+/// Default for [`Config::import_timeout_secs`] (2h), enforced at the type level
+/// so the documented default holds even without the Figment default layer.
+fn default_import_timeout_secs() -> u64 {
+    7200
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
     bind_address: String,
@@ -55,8 +61,9 @@ pub struct Config {
     /// How long (seconds) to keep polling for a transfer to be imported before
     /// giving up watching it. Bounds the per-transfer import-watch loop so a
     /// transfer that never fully imports (e.g. one with a sample the *arr won't
-    /// import) can't accumulate and stall downloads. Default 7200 (2h).
-    #[serde(default)]
+    /// import) can't accumulate and stall downloads. Default 7200 (2h); 0
+    /// disables the bound (watch indefinitely).
+    #[serde(default = "default_import_timeout_secs")]
     import_timeout_secs: u64,
     port: u16,
     skip_directories: Vec<String>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,12 @@ uid = 1000
 # Optional polling interval in secs, default 10.
 polling_interval = 10
 
+# Optional. Give up watching a transfer for import after this many seconds, default 7200 (2h).
+# Bounds the per-transfer import-watch loop so a transfer that never fully imports (e.g. one
+# containing a sample the *arr won't import) can't accumulate and eventually stall downloads.
+# Set to 0 to disable (watch indefinitely).
+import_timeout_secs = 7200
+
 # Optional skip directories when downloading, default ["sample", "extras"]
 skip_directories = ["sample", "extras"]
 


### PR DESCRIPTION
Fixes #30.

## Problem

`watch_for_import` polls `is_imported()` in an unbounded loop and only exits once *every* video file of a transfer is imported:

```rust
loop {
    if transfer.is_imported().await { /* clean up, send Imported */ break; }
    sleep(polling_interval).await;
}
```

If a transfer contains a video file the *arr will never import — most commonly a **sample** that isn't inside a `skip_directories` folder — `is_imported()` is permanently false and the task loops forever. Each such transfer leaves a forever-running task polling the *arr/put.io APIs every `polling_interval`. They accumulate, and after ~10h with a large library the process stops picking up newly-completed transfers entirely (downloads stall with many `COMPLETED` transfers left un-pulled on put.io). A restart only clears it temporarily.

The tell-tale sign in the logs is the *main* file of the same transfer being reported `found imported by radarr` over and over every ~10s — the movie imported fine, but a sibling sample keeps the transfer from ever completing.

## Fix

Give up watching after `MAX_IMPORT_WAIT` (2h) with a warning, so a stuck transfer ends its task instead of polling forever. Genuine imports are detected within a poll or two of the *arr importing, so this generous bound doesn't affect normal operation; it just caps how long a never-importing transfer can sit in a polling loop.

This is a targeted fix for the stall. The deeper fix is better import-mapping (the existing `skip_directories` TODO — e.g. ignoring sample files, or treating a transfer as imported once it has left the *arr download queue), which would let these transfers complete and be cleaned up rather than be abandoned.

## Note

A given-up transfer's local and put.io copies are no longer auto-cleaned (it stops being tracked). That's a deliberate trade-off — leaking one stuck transfer is far better than stalling every download — and it is re-evaluated on the next restart.