### PR TITLE
fix: pull unmanaged active transfers from watch folders

### DIFF
--- a/src/download_system/transfer.rs
+++ b/src/download_system/transfer.rs
@@ -461,7 +461,19 @@ async fn scan_watch_folders(
         return;
     }
     let api_key = &app_data.config.putio.api_key;
-    let active_file_ids: HashSet<i64> = active_transfers.iter().filter_map(|t| t.file_id).collect();
+    // Only files backed by a *managed* active transfer are handled the normal
+    // way by the main loop. Unmanaged active transfers (e.g. a manually added
+    // put.io Watch List entry, or one whose state was lost) are skipped there,
+    // so their completed files must be picked up here as orphans — otherwise
+    // both paths ignore them and they are never downloaded/imported.
+    let mut managed_active_file_ids: HashSet<i64> = HashSet::new();
+    for t in active_transfers {
+        if let Some(file_id) = t.file_id {
+            if is_managed(app_data, t).await {
+                managed_active_file_ids.insert(file_id);
+            }
+        }
+    }
 
     for folder_id in &app_data.config.watch_folders {
         let resp = match putio::list_files(api_key, *folder_id).await {
@@ -477,11 +489,13 @@ async fn scan_watch_folders(
             if file.id < 0 || !matches!(file.file_type.as_str(), "FOLDER" | "VIDEO" | "AUDIO") {
                 continue;
             }
-            // Skip the result of an active transfer (handled the normal way) and
-            // any orphan we're already pulling. Using `has_orphan` as the
-            // "in progress" marker keeps tracking bounded and, since a failed
-            // orphan is dropped from it, lets a later poll retry it.
-            if active_file_ids.contains(&file.id) || app_data.state.has_orphan(file.id).await {
+            // Skip the result of a *managed* active transfer (handled the normal
+            // way) and any orphan we're already pulling. Files from unmanaged
+            // active transfers fall through the main loop, so they are handled
+            // here. Using `has_orphan` as the "in progress" marker keeps tracking
+            // bounded and, since a failed orphan is dropped from it, lets a later
+            // poll retry it.
+            if managed_active_file_ids.contains(&file.id) || app_data.state.has_orphan(file.id).await {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Follow-up to #35 (orphan watch-folder scan). Manually added put.io transfers
(a Watch List entry, or any transfer whose local state was lost) still never
reach the local downloader — they fall through **both** code paths:

- the main transfer loop skips unmanaged transfers (#9), **and**
- `scan_watch_folders` skips every file whose id belongs to an *active*
  transfer, regardless of whether that transfer is managed.

So an unmanaged transfer that is still active on put.io is ignored by the loop
*and* excluded from the orphan scan: its completed files are never downloaded
or imported.

## Fix

`scan_watch_folders` now excludes only files backed by a **managed** active
transfer. Files from unmanaged active transfers are treated as orphans and
routed to the correct category (radarr/sonarr), like any other orphaned
watch-folder file.

## Testing

Built and deployed to a live instance (640 transfers). Previously-stuck
unmanaged transfers are now picked up by the orphan scan and routed correctly
— e.g. `museum...s01e09` → `/downloads/tv` (imported by sonarr), and a
manually added movie began downloading instead of being skipped indefinitely.
